### PR TITLE
Add new item change catch for MenuItem 'Visible' property

### DIFF
--- a/System/Windows/Forms/Menu.cs
+++ b/System/Windows/Forms/Menu.cs
@@ -883,6 +883,14 @@ namespace System.Windows.Forms
             {
                 DestroyMenuItems();
             }
+            else if ((uint)change == 4)
+            {
+                DestroyMenuItems();
+                CreateMenuItems();
+                foreach (MenuItem item in MenuItems) {
+                    item.UpdateMenuItem(true);
+                }
+            }
         }
 
         private IntPtr MatchKeyToMenuItem(int startItem, char key, MenuItemKeyComparer comparer)

--- a/System/Windows/Forms/MenuItem.cs
+++ b/System/Windows/Forms/MenuItem.cs
@@ -155,7 +155,7 @@ namespace System.Windows.Forms
                     if ((state & 0x10000) == 0 != value)
                     {
                         state = (value ? (state & -65537) : (state | 0x10000));
-                        ItemsChanged(1);
+                        ItemsChanged(4);
                     }
                 }
             }


### PR DESCRIPTION
The 'Visible' property is a bit broken.

* MainMenu will cease to work if one of its items visibility is changed (since 1 destroys the menu and does nothing else)
* MenuItems with nested items will not pop out the menu if one of the items within that menu has its visibility changed

This patches those known issues, I have not ran into anymore.